### PR TITLE
Add doctests and ensure mix docs compiles

### DIFF
--- a/lib/trieval.ex
+++ b/lib/trieval.ex
@@ -18,7 +18,7 @@ defmodule Trieval do
       %Trieval.Trie{trie: %{}}
 
   """
-  @spec new() :: %Trieval.Trie{trie: map()}
+  @spec new() :: Trieval.Trie.t(trie: map())
   def new, do: %Trie{}
 
   @doc """
@@ -49,7 +49,7 @@ defmodule Trieval do
               }
 
   """
-  @spec new(binary() | maybe_improper_list() | {binary(), any()}) :: %Trieval.Trie{trie: map()}
+  @spec new(binary() | maybe_improper_list() | {binary(), any()}) :: Trieval.Trie.t(trie: map())
   def new(binaries) when is_list(binaries) do
     insert(%Trie{}, binaries)
   end
@@ -74,8 +74,8 @@ defmodule Trieval do
       %Trieval.Trie{trie: %{...}}
 
   """
-  @spec insert(%Trieval.Trie{trie: map()}, binary() | maybe_improper_list() | {binary(), any()}) ::
-          %Trieval.Trie{trie: map()}
+  @spec insert(Trieval.Trie.t(trie: map()), binary() | maybe_improper_list() | {binary(), any()}) ::
+          Trieval.Trie.t(trie: map())
   def insert(%Trie{trie: trie}, binaries) when is_list(binaries) do
     %Trie{trie: Enum.reduce(binaries, trie, &_insert(&2, &1))}
   end
@@ -122,7 +122,7 @@ defmodule Trieval do
       false
 
   """
-  @spec contains?(%Trieval.Trie{trie: map()}, binary()) :: boolean()
+  @spec contains?(Trieval.Trie.t(trie: map()), binary()) :: boolean()
   def contains?(%Trie{trie: trie}, binary) when is_binary(binary) do
     _contains?(trie, binary)
   end
@@ -154,7 +154,7 @@ defmodule Trieval do
       []
 
   """
-  @spec prefix(%Trieval.Trie{trie: map()}, binary()) :: list()
+  @spec prefix(Trieval.Trie.t(trie: map()), binary()) :: list()
   def prefix(%Trie{trie: trie}, binary) when is_binary(binary) do
     _prefix(trie, binary, binary)
   end
@@ -190,7 +190,7 @@ defmodule Trieval do
       {nil, []}
 
   """
-  @spec longest_common_prefix(%Trieval.Trie{trie: map()}, binary()) ::
+  @spec longest_common_prefix(Trieval.Trie.t(trie: map()), binary()) ::
           {[nil | bitstring()], list()}
   def longest_common_prefix(%Trie{trie: trie}, binary) when is_binary(binary) do
     _longest_common_prefix(trie, binary, binary)
@@ -252,7 +252,7 @@ defmodule Trieval do
       {:error, "Dangling group (exclusion) starting at column 8, expecting ]"}
 
   """
-  @spec pattern(%Trieval.Trie{trie: map()}, binary()) :: list() | {:error, <<_::64, _::_*8>>}
+  @spec pattern(Trieval.Trie.t(trie: map()), binary()) :: list() | {:error, <<_::64, _::_*8>>}
   def pattern(%Trie{trie: trie}, pattern) when is_binary(pattern) do
     _pattern(trie, %{}, pattern, <<>>, :parse)
   end

--- a/lib/trieval.ex
+++ b/lib/trieval.ex
@@ -74,7 +74,8 @@ defmodule Trieval do
       %Trieval.Trie{trie: %{...}}
 
   """
-  @spec insert(%Trieval.Trie{trie: map()}, binary() | maybe_improper_list() | {binary(), any()}) :: %Trieval.Trie{trie: map()}
+  @spec insert(%Trieval.Trie{trie: map()}, binary() | maybe_improper_list() | {binary(), any()}) ::
+          %Trieval.Trie{trie: map()}
   def insert(%Trie{trie: trie}, binaries) when is_list(binaries) do
     %Trie{trie: Enum.reduce(binaries, trie, &_insert(&2, &1))}
   end
@@ -189,7 +190,8 @@ defmodule Trieval do
       {nil, []}
 
   """
-  @spec longest_common_prefix(%Trieval.Trie{trie: map()}, binary()) :: {[nil | bitstring()], list()}
+  @spec longest_common_prefix(%Trieval.Trie{trie: map()}, binary()) ::
+          {[nil | bitstring()], list()}
   def longest_common_prefix(%Trie{trie: trie}, binary) when is_binary(binary) do
     _longest_common_prefix(trie, binary, binary)
   end

--- a/lib/trieval.ex
+++ b/lib/trieval.ex
@@ -3,28 +3,53 @@ defmodule Trieval do
   alias Trieval.PatternParser
 
   @moduledoc """
-  Provides an interface for creating and collecting data from the trie data structure.
+  Trieval provides an interface for creating and managing trie data structures. A trie, also known as a prefix tree, is a type of search tree used to store associative data structures.
+
+  This module provides functions to create new tries, insert values, and perform various operations on the trie. It supports creating tries from binaries, lists of binaries, and tuples of binaries.
   """
 
   @doc """
-  Returns a new trie. Providing no arguments creates an empty trie. Optionally a binary or
-  list of binaries can be passed to `new/1`.
+  Returns a new trie. Providing no arguments creates an empty trie.
+  Optionally, a binary, a list of binaries or a tuple of binaries can be passed to `new/1`.
 
   ## Examples
 
-        Trieval.new
-        %Trieval.Trie{...}
-
-        Trieval.new("apple")
-        %Trieval.Trie{...}
-
-        Trieval.new(~w/apple apply ape ample/)
-        %Trieval.Trie{...}
+      iex> Trieval.new()
+      %Trieval.Trie{trie: %{}}
 
   """
-
+  @spec new() :: %Trieval.Trie{trie: map()}
   def new, do: %Trie{}
 
+  @doc """
+  Returns a new trie containing lists of binaries representing the provided values passed to `new/1`.
+  Optional values are a binary, a list of binaries or a tuple of binaries can be passed to `new/1`.
+
+  ## Examples
+
+      iex> Trieval.new("apple")
+      %Trieval.Trie{trie: %{97 => %{112 => %{112 => %{108 => %{101 => %{mark: :mark}}}}}}}
+
+      iex> Trieval.new(~w/apple apply ape ample/)
+      %Trieval.Trie{
+                trie: %{
+                  97 => %{
+                    109 => %{112 => %{108 => %{101 => %{mark: :mark}}}},
+                    112 => %{
+                      101 => %{mark: :mark},
+                      112 => %{
+                        108 => %{
+                          101 => %{mark: :mark},
+                          121 => %{mark: :mark}
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+
+  """
+  @spec new(binary() | maybe_improper_list() | {binary(), any()}) :: %Trieval.Trie{trie: map()}
   def new(binaries) when is_list(binaries) do
     insert(%Trie{}, binaries)
   end
@@ -38,18 +63,18 @@ defmodule Trieval do
   end
 
   @doc """
-  Inserts a binary or list of binaries into an existing trie.
+  Inserts a binary, list of binaries or tuple of binaries into an existing trie.
 
   ## Examples
 
-        Trieval.new |> Trieval.insert("apple")
-        %Trieval.Trie{...}
+      iex> Trieval.new() |> Trieval.insert("apple")
+      %Trieval.Trie{trie: %{97 => %{112 => %{112 => %{108 => %{101 => %{mark: :mark}}}}}}}
 
-        Trieval.new(~w/apple apply ape ample/) |> Trieval.insert(~w/zebra corgi/)
-        %Trieval.Trie{...}
+      Trieval.new(~w/apple apply ape ample/) |> Trieval.insert(~w/zebra corgi/)
+      %Trieval.Trie{trie: %{...}}
 
   """
-
+  @spec insert(%Trieval.Trie{trie: map()}, binary() | maybe_improper_list() | {binary(), any()}) :: %Trieval.Trie{trie: map()}
   def insert(%Trie{trie: trie}, binaries) when is_list(binaries) do
     %Trie{trie: Enum.reduce(binaries, trie, &_insert(&2, &1))}
   end
@@ -89,14 +114,14 @@ defmodule Trieval do
 
   ## Examples
 
-        Trieval.new(~w/apple apply ape ample/) |> Trieval.contains?("apple")
-        true
+      iex> Trieval.new(~w/apple apply ape ample/) |> Trieval.contains?("apple")
+      true
 
-        Trieval.new(~w/apple apply ape ample/) |> Trieval.contains?("zebra")
-        false
+      iex> Trieval.new(~w/apple apply ape ample/) |> Trieval.contains?("zebra")
+      false
 
   """
-
+  @spec contains?(%Trieval.Trie{trie: map()}, binary()) :: boolean()
   def contains?(%Trie{trie: trie}, binary) when is_binary(binary) do
     _contains?(trie, binary)
   end
@@ -121,14 +146,14 @@ defmodule Trieval do
 
   ## Examples
 
-        Trieval.new(~w/apple apply ape ample/) |> Trieval.prefix("ap")
-        ["apple", "apply", "ape"]
+      iex> Trieval.new(~w/apple apply ape ample/) |> Trieval.prefix("ap")
+      ["ape", "apple", "apply"]
 
-        Trieval.new(~w/apple apply ape ample/) |> Trieval.prefix("z")
-        []
+      iex> Trieval.new(~w/apple apply ape ample/) |> Trieval.prefix("z")
+      []
 
   """
-
+  @spec prefix(%Trieval.Trie{trie: map()}, binary()) :: list()
   def prefix(%Trie{trie: trie}, binary) when is_binary(binary) do
     _prefix(trie, binary, binary)
   end
@@ -157,14 +182,14 @@ defmodule Trieval do
 
   ## Examples
 
-        Trieval.new(~w/apple apply ape/) |> Trieval.longest_common_prefix("a")
-        {"ap", ["apple", "apply", "ape"]}
+      iex> Trieval.new(~w/apple apply ape/) |> Trieval.longest_common_prefix("a")
+      {"ap", ["ape", "apple", "apply"]}
 
-        Trieval.new(~w/apple apply ape ample/) |> Trieval.longest_common_prefix("z")
-        {nil, []}
+      iex> Trieval.new(~w/apple apply ape ample/) |> Trieval.longest_common_prefix("z")
+      {nil, []}
 
   """
-
+  @spec longest_common_prefix(%Trieval.Trie{trie: map()}, binary()) :: {[nil | bitstring()], list()}
   def longest_common_prefix(%Trie{trie: trie}, binary) when is_binary(binary) do
     _longest_common_prefix(trie, binary, binary)
   end
@@ -209,23 +234,23 @@ defmodule Trieval do
 
   ## Examples
 
-        Trieval.new(~w/apple apply ape ample/) |> Trieval.pattern("a{1}{1}**")
-        ["apple", "apply"]
+      iex> Trieval.new(~w/apple apply ape ample/) |> Trieval.pattern("a{1}{1}**")
+      ["apple", "apply"]
 
-        Trieval.new(~w/apple apply ape ample/) |> Trieval.pattern("*{1[^p]}{1}**")
-        []
+      iex> Trieval.new(~w/apple apply ape ample/) |> Trieval.pattern("*{1[^p]}{1}**")
+      []
 
-        Trieval.new(~w/apple apply zebra house/) |> Trieval.pattern("[hz]****")
-        ["house", "zebra"]
+      iex> Trieval.new(~w/apple apply zebra house/) |> Trieval.pattern("[hz]****")
+      ["house", "zebra"]
 
-        Trieval.new(~w/apple apply zebra house/) |> Trieval.pattern("[hz]***[^ea]")
-        []
+      iex> Trieval.new(~w/apple apply zebra house/) |> Trieval.pattern("[hz]***[^ea]")
+      []
 
-        Trieval.new(~w/apple apply zebra house/) |> Trieval.pattern("[hz]***[^ea")
-        {:error, "Dangling group (exclusion) starting at column 8, expecting ]"}
+      iex> Trieval.new(~w/apple apply zebra house/) |> Trieval.pattern("[hz]***[^ea")
+      {:error, "Dangling group (exclusion) starting at column 8, expecting ]"}
 
   """
-
+  @spec pattern(%Trieval.Trie{trie: map()}, binary()) :: list() | {:error, <<_::64, _::_*8>>}
   def pattern(%Trie{trie: trie}, pattern) when is_binary(pattern) do
     _pattern(trie, %{}, pattern, <<>>, :parse)
   end

--- a/test/trieval_test.exs
+++ b/test/trieval_test.exs
@@ -1,5 +1,5 @@
 defmodule TrievalTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest Trieval
 
   @test_data ~w/apple apply ape bed between betray cat cold hot


### PR DESCRIPTION
This PR adds more updates to the repo for publishing preparation. [Ticket](https://github.com/pathpub/trieval/issues/2#issue-2759931732)

Updates:
- Adds doctests and function specs in `Trieval` for better compiled documentation as recommended by Mix for publishing.
- Locally running `mix docs` works without errors! This auto-generates all our documentation based on the new doctests and moduledocs which hex will use when publishing.
- Added `async: true` option to `use ExUnit.Case` in `TrievalTest` file. This runs test modules concurrently which isn't currently helpful but appears to be a best practice and will be 1 less thing to introduce later when we have multiple test modules. This `might` already be used due to the new inclusion of doctests and function specs but I'm not entirely sure.

Still needs to be done:
- README updates